### PR TITLE
Workaround for subprocess.DEVNULL ImportError (On Python 3.2)

### DIFF
--- a/tmc/__main__.py
+++ b/tmc/__main__.py
@@ -5,7 +5,14 @@ import getpass
 import os
 import sys
 from functools import wraps
-from subprocess import DEVNULL, Popen
+from subprocess import Popen
+
+try:
+    from subprocess import DEVNULL
+except ImportError:
+    import os
+    DEVNULL = open(os.devnull, 'wb')
+
 
 import argh
 import peewee


### PR DESCRIPTION
DEVNULL: New in version 3.3.
https://docs.python.org/3.3/library/subprocess.html
