### PR TITLE
Ensure trailing '/' in server URL given by user

### DIFF
--- a/tmc/__main__.py
+++ b/tmc/__main__.py
@@ -79,6 +79,7 @@ def configure(server=None, username=None, password=None, id=None):
             server = "https://tmc.mooc.fi/mooc/"
         if not server.endswith('/'):
             server += '/'
+        print("Using URL: '{0}'".format(server))
     while True:
         if not username:
             username = input("Username: ")


### PR DESCRIPTION
For example if user gives server URL without trailing slash, requests will be made to /tmccourses.json instead of /tmc/courses.json.

Also added a print to show user the actual (possibly modified) URL used.
