### PR TITLE
```tmc configure``` prompts user for download directory even with --id

### DIFF
--- a/tmc/__main__.py
+++ b/tmc/__main__.py
@@ -73,19 +73,17 @@ def false_exit(func):
 @arg("-u", "--username", help="Username to be used.")
 @arg("-p", "--password", help="Password to be used.")
 @arg("-i", "--id", dest="tid", help="Course ID to be used.")
+@arg("-a", "--auto", action="store_true", help="Don't prompt for download path, use default instead")
 @false_exit
-def configure(server=None, username=None, password=None, tid=None):
+def configure(server=None, username=None, password=None, tid=None, auto=False):
     """
     Configure tmc.py to use your account.
     """
-    auto = False
     if not server and not username and not password and not tid:
         if Config.has():
             sure = input("Override old configuration [y/N]: ")
             if sure.upper() != "Y":
                 return False
-    else:
-        auto = True
     reset_db()
     if not server:
         while True:
@@ -132,7 +130,7 @@ def configure(server=None, username=None, password=None, tid=None):
             return False
         break
     if tid:
-        select(course=True, tid=tid, auto=True)
+        select(course=True, tid=tid, auto=auto)
     else:
         select(course=True)
 


### PR DESCRIPTION
This is how I (as an user) would prefer the `tmc configure` to work (and thought what `configure` _would_ do), i.e. prompt the user for the download directory, even if user specifies  the course `--id`. The old behavior (using the default `~/tmc/course` directory) can be enabled with `--auto` flag. 

I can imagine many other sensible ways of implementing a similar functionality (e.g. providing `--path` argument to allow user to specify the download dir) you might prefer instead; I'm making this pull request just to give an idea :-) .

If there's some reason (that I didn't realize) why `configure` shouldn't work like this, alternatively please update the documentation to at least note that if the course is selected with `configure --id`, tmc.py will use the default `~/tmc/course` directory.

(Apologies for the slightly botched up commit history.)
