### PR TITLE
Use secure protocol when checking pypi for package updates.

### DIFF
--- a/tmc/__main__.py
+++ b/tmc/__main__.py
@@ -76,7 +76,7 @@ def false_exit(func):
 def check_for_updates():
     from xmlrpc.client import ServerProxy
     from distutils.version import StrictVersion
-    pypi = ServerProxy("http://pypi.python.org/pypi")
+    pypi = ServerProxy("https://pypi.python.org/pypi")
     version = StrictVersion(__version__)
     pypiversion = StrictVersion(pypi.package_releases("tmc")[0])
     if pypiversion > version:


### PR DESCRIPTION
Fixes xmlrpc exception below, observed in python3.5.

```
xmlrpc.client.ProtocolError: <ProtocolError for pypi.python.org/pypi: 403 Must access using HTTPS instead of HTTP>
```
